### PR TITLE
fix: markdown formatting of messages with attachments

### DIFF
--- a/src/telegram/bot/message/convertToMarkdown.ts
+++ b/src/telegram/bot/message/convertToMarkdown.ts
@@ -4,7 +4,8 @@ import { getInlineUrls } from "./getters";
 export async function convertMessageTextToMarkdown(msg: TelegramBot.Message): Promise<string> {
 	let text = msg.text || msg.caption || "";
 	const entities = msg.entities || msg.caption_entities || [];
-	entities.forEach((entity, index, updatedEntities) => {
+	const copiedEntities: TelegramBot.MessageEntity[] = structuredClone(entities);
+	copiedEntities.forEach((entity, index, updatedEntities) => {
 		const entityStart = entity.offset;
 		let entityEnd = entityStart + entity.length;
 		let entityText = text.slice(entityStart, entityEnd);


### PR DESCRIPTION
The `convertMessageTextToMarkdown` function used to mutate `msg` argument passed to it. This caused improper markdown formatting for some messages (messages with attachments are affected, I didn't investigate other criteria)