### PR TITLE
feat: add proxy URL setting for bot connection

### DIFF
--- a/src/settings/Settings.ts
+++ b/src/settings/Settings.ts
@@ -68,6 +68,7 @@ export interface TelegramSyncSettings {
 	processOldMessagesSettings: ProcessOldMessagesSettings;
 	processOtherBotsMessages: boolean;
 	retryFailedMessagesProcessing: boolean;
+	proxyUrl: string;
 	// add new settings above this line
 	topicNames: Topic[];
 }
@@ -92,6 +93,7 @@ export const DEFAULT_SETTINGS: TelegramSyncSettings = {
 	processOldMessagesSettings: getDefaultProcessOldMessagesSettings(),
 	processOtherBotsMessages: false,
 	retryFailedMessagesProcessing: false,
+	proxyUrl: "",
 	// add new settings above this line
 	topicNames: [],
 };

--- a/src/settings/modals/AdvancedSettings.ts
+++ b/src/settings/modals/AdvancedSettings.ts
@@ -21,6 +21,7 @@ export class AdvancedSettingsModal extends Modal {
 		this.addDeleteMessagesFromTelegram();
 		this.addMessageDelimiterSetting();
 		this.addParallelMessageProcessing();
+		this.addProxyUrl();
 	}
 
 	addHeader() {
@@ -80,6 +81,20 @@ export class AdvancedSettingsModal extends Modal {
 				toggle.setValue(this.plugin.settings.deleteMessagesFromTelegram);
 				toggle.onChange(async (value) => {
 					this.plugin.settings.deleteMessagesFromTelegram = value;
+					await this.plugin.saveSettings();
+				});
+			});
+	}
+
+	addProxyUrl() {
+		new Setting(this.advancedSettingsDiv)
+			.setName("Proxy URL")
+			.setDesc("HTTP proxy for connecting to Telegram (e.g., http://127.0.0.1:7897). Restart the plugin after changing.")
+			.addText((text) => {
+				text.setPlaceholder("http://127.0.0.1:7897");
+				text.setValue(this.plugin.settings.proxyUrl);
+				text.onChange(async (value) => {
+					this.plugin.settings.proxyUrl = value.trim();
 					await this.plugin.saveSettings();
 				});
 			});

--- a/src/telegram/bot/bot.ts
+++ b/src/telegram/bot/bot.ts
@@ -18,7 +18,11 @@ export async function connect(plugin: TelegramSyncPlugin) {
 			return;
 		}
 		// Create a new bot instance and start polling
-		plugin.bot = new TelegramBot(await enqueue(plugin, plugin.getBotToken));
+		const botOptions: TelegramBot.ConstructorOptions = {};
+		if (plugin.settings.proxyUrl) {
+			botOptions.request = { proxy: plugin.settings.proxyUrl };
+		}
+		plugin.bot = new TelegramBot(await enqueue(plugin, plugin.getBotToken), botOptions);
 		const bot = plugin.bot;
 		// Set connected flag to false and log errors when a polling error occurs
 		bot.on("polling_error", async (error: unknown) => {


### PR DESCRIPTION
## Summary

- Add a proxy URL setting in Bot Settings, allowing users to configure a proxy for the Telegram bot connection
- Useful for users in regions where Telegram is blocked (e.g. China, Iran) or in restricted corporate networks

## Changes

- Added `proxyUrl` field to plugin settings
- Added proxy URL input in Bot Settings modal
- Applied proxy configuration to `TelegramBot` initialization via `request.proxy`

## Test plan

- [ ] Configure a proxy URL in Bot Settings and verify the bot connects through it
- [ ] Leave proxy URL empty and verify the bot connects directly as before